### PR TITLE
[fix] Fix page grid images

### DIFF
--- a/src/components/CollectionPage/CollectionPage.js
+++ b/src/components/CollectionPage/CollectionPage.js
@@ -12,9 +12,10 @@ import { pages as PAGES } from './collections.json'
 function CollectionPage() {
   const data = useStaticQuery(graphql`
   query {
-    gridImages: allFile(filter: { name: { regex: "/page-1-grid-*/" }, extension: { regex: "/(jpeg|jpg|gif|png)/" }, sourceInstanceName: { eq: "images"}}) {
+    gridImages: allFile(filter: { name: { regex: "/-grid-*/" }, extension: { regex: "/(jpeg|jpg|gif|png)/" }, sourceInstanceName: { eq: "images"}}) {
       edges {
         node {
+          name
           childImageSharp {
             fluid(maxWidth: 300) {
               ...GatsbyImageSharpFluid
@@ -120,7 +121,7 @@ function CollectionPage() {
       </div>
 
       <div className="image-grid">
-        <Grid items={data.gridImages.edges} />
+        <Grid items={data.gridImages.edges} page={page+1} />
       </div>
 
     </div>

--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -8,14 +8,19 @@ function shuffle(array) {
   array.sort(() => Math.random() - 0.5)
 }
 
-function Grid({ items }) {
+function Grid({ items, page }) {
 
   shuffle(items)
-
+  const pageItems = []
+  items.map(({ node }) => {
+    if (node.name.includes(('page-'+page+'-grid'))) { 
+      pageItems.push({'node':node})
+    }
+  })
   return (
     <div className='grid-container'>
       {
-        items.map(({ node }) =>
+        pageItems.map(({ node }) =>
           <GridItem>
             <Img fluid={node.childImageSharp.fluid} />
           </GridItem>


### PR DESCRIPTION
I thought this template was really good and used it to create a portfolio.
I fixed it because there was a small error in displaying the grid images for each page.
(I'm not good at ReactJS, so the fix may be awkward.)
Please reflect after review.

```
 gridImages: allFile(filter: { name: { regex: "/page-1-grid-*/" }, extension: { regex: "/(jpeg|jpg|gif|png)/" }, sourceInstanceName: { eq: "images"}}) {
      edges {
        node {
          name
          childImageSharp {
            fluid(maxWidth: 300) {
              ...GatsbyImageSharpFluid
            }
          }
        }
      }
    }
```